### PR TITLE
Fixed bug with SSL providers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,10 @@ MAINTAINER Tim Haak <tim@haak.co.uk>
 RUN apt-get -q update
 RUN apt-get -qy --force-yes dist-upgrade
 
-RUN apt-get install -qy --force-yes  python git-core
+RUN apt-get install -qy --force-yes  python git-core software-properties-common python-pip build-essential python-dev libffi-dev libssl-dev
+RUN apt-get -q update
+RUN pip install --upgrade cryptography pyopenssl ndg-httpsclient pyasn1
+
 RUN git clone https://github.com/RuudBurger/CouchPotatoServer.git /CouchPotatoServer
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ RUN apt-get -q update
 RUN apt-get -qy --force-yes dist-upgrade
 
 RUN apt-get install -qy --force-yes  python git-core software-properties-common python-pip build-essential python-dev libffi-dev libssl-dev
-RUN apt-get -q update
 RUN pip install --upgrade cryptography pyopenssl ndg-httpsclient pyasn1
 
 RUN git clone https://github.com/RuudBurger/CouchPotatoServer.git /CouchPotatoServer


### PR DESCRIPTION
After a recent couchpotato update, I noticed the following error cropping up in my logs:

```
5-07 10:26:30 ERROR [edia._base.providers.base] Failed to login to: SceneAccess
05-07 10:26:31 INFO [hpotato.core.plugins.base] Opening url: post https://www.sceneaccess.eu/login, data: ['username', 'password', 'submit']
05-07 10:26:31 ERROR [hpotato.core.plugins.base] Failed opening url in SceneAccess: https://www.sceneaccess.eu/login Traceback (most recent call last):
SSLError: [Errno 1] _ssl.c:510: error:14077438:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert internal error

05-07 10:26:31 ERROR [edia._base.providers.base] Failed to login SceneAccess: Traceback (most recent call last):
  File "/CouchPotatoServer/couchpotato/core/media/_base/providers/base.py", line 159, in login
--
    r = adapter.send(request, **kwargs)
  File "/CouchPotatoServer/libs/requests/adapters.py", line 431, in send
    raise SSLError(e, request=request)
SSLError: [Errno 1] _ssl.c:510: error:14077438:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert internal error
```

After spending some time reading through Sickrage's (yep) issue tracker, it seems they have had the same problem in recent days. More info and solution here: https://github.com/SiCKRAGETV/sickrage-issues/wiki/SSL-Errors

It seems CouchPotato has fallen prey to the same problem. This pull request should fix that problem.

Heads up, if you're happy with this approach, I'll send up a pull request for docker-sickrage too.