### PR TITLE
Use exec in start script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -6,4 +6,4 @@ mkdir -p /data
 cd /CouchPotatoServer
 touch /config/CouchPotato.cfg
 
-/usr/bin/python /CouchPotatoServer/CouchPotato.py --data_dir /data/ --config_file=/config/CouchPotato.cfg --console_log
+exec /usr/bin/python /CouchPotatoServer/CouchPotato.py --data_dir /data/ --config_file=/config/CouchPotato.cfg --console_log


### PR DESCRIPTION
Ensures the CouchPotato process is PID 1 for correct signal handling

Fixes #5 