### PR TITLE
Bugfix change py-pip to py2-pip to make apt-get working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV LANG='en_US.UTF-8' \
 RUN apk -U upgrade && \
     apk -U add \
         ca-certificates git \
-        py-pip ca-certificates git python py-libxml2 py-lxml py-pip  \
+        py2-pip ca-certificates git python py-libxml2 py-lxml py-pip  \
         make gcc g++ python-dev openssl-dev libffi-dev \
     && \
     pip --no-cache-dir install --upgrade setuptools && \


### PR DESCRIPTION
Original does not build with error:
ERROR: unsatisfiable constraints:
  py-pip (virtual):
    provided by: py2-pip
    required by: world[py-pip]
Changing py-pip to py2-pip fixes this
